### PR TITLE
fix deposit max amount of azero tokens

### DIFF
--- a/src/store/sagas/positions.ts
+++ b/src/store/sagas/positions.ts
@@ -9,6 +9,7 @@ import {
   INVARIANT_CREATE_POSITION_OPTIONS,
   INVARIANT_REMOVE_POSITION_OPTIONS,
   INVARIANT_WITHDRAW_ALL_WAZERO,
+  POOL_SAFE_TRANSACTION_FEE,
   POSITIONS_PER_QUERY,
   PSP22_APPROVE_OPTIONS,
   U128MAX,
@@ -122,8 +123,13 @@ function* handleInitPosition(action: PayloadAction<InitPositionData>): Generator
       (tokenY === wazeroAddress && tokenYAmount !== 0n)
     ) {
       const isTokenX = tokenX === wazeroAddress
+      const azeroInputAmount = isTokenX ? tokenXAmount : tokenYAmount
+
       const slippageAmount = isTokenX ? xAmountWithSlippage : yAmountWithSlippage
-      const azeroAmount = azeroBalance > slippageAmount ? slippageAmount : azeroBalance
+      const azeroAmount =
+        azeroBalance - POOL_SAFE_TRANSACTION_FEE > slippageAmount
+          ? slippageAmount
+          : azeroInputAmount
 
       const depositTx = wazero.depositTx(azeroAmount, WAZERO_DEPOSIT_OPTIONS)
       txs.push(depositTx)

--- a/src/store/sagas/swap.ts
+++ b/src/store/sagas/swap.ts
@@ -15,6 +15,7 @@ import {
   ErrorMessage,
   INVARIANT_SWAP_OPTIONS,
   PSP22_APPROVE_OPTIONS,
+  SWAP_SAFE_TRANSACTION_FEE,
   U128MAX,
   WAZERO_DEPOSIT_OPTIONS,
   WAZERO_WITHDRAW_OPTIONS
@@ -98,7 +99,10 @@ export function* handleSwap(action: PayloadAction<Omit<Swap, 'txid'>>): Generato
     if ((xToY && poolKey.tokenX === wazeroAddress) || (!xToY && poolKey.tokenY === wazeroAddress)) {
       const azeroBalance = yield* select(balance)
       const azeroAmountInWithSlippage =
-        azeroBalance > calculatedAmountIn ? calculatedAmountIn : azeroBalance
+        azeroBalance - SWAP_SAFE_TRANSACTION_FEE > calculatedAmountIn
+          ? calculatedAmountIn
+          : amountIn
+
       const depositTx = wazero.depositTx(azeroAmountInWithSlippage, WAZERO_DEPOSIT_OPTIONS)
       txs.push(depositTx)
     }


### PR DESCRIPTION
- fix deposit max amount of azero tokens 
reproduction of bug:
set slippage to 10% 
deposit bigger amount of azero in swap or new position by 'max' button. 
